### PR TITLE
Implement *.Index, *.At, *.Contains

### DIFF
--- a/docs/Photons/At.md
+++ b/docs/Photons/At.md
@@ -1,0 +1,19 @@
+## Module Photons.At
+
+#### `At`
+
+``` purescript
+class (Index m a b) <= At m a b where
+  at :: a -> LensP m (Maybe b)
+```
+
+##### Instances
+``` purescript
+instance atIdentity :: At (Identity a) Unit a
+instance atMaybe :: At (Maybe a) Unit a
+instance atSet :: (Ord v) => At (Set v) v Unit
+instance atMap :: (Ord k) => At (Map k v) k v
+instance atStrMap :: At (StrMap v) String v
+```
+
+

--- a/docs/Photons/Contains.md
+++ b/docs/Photons/Contains.md
@@ -1,0 +1,15 @@
+## Module Photons.Contains
+
+#### `Contains`
+
+``` purescript
+class (IndexKey m a) <= Contains m a where
+  contains :: a -> LensP m Boolean
+```
+
+##### Instances
+``` purescript
+instance containsSet :: (Ord k) => Contains (Set k) k
+```
+
+

--- a/docs/Photons/Fold.md
+++ b/docs/Photons/Fold.md
@@ -1,0 +1,226 @@
+## Module Photons.Fold
+
+This module defines functions for working with folds.
+
+#### `preview`
+
+``` purescript
+preview :: forall s t a b. Fold (First a) s t a b -> s -> Maybe a
+```
+
+Previews the first value of a fold, if there is any.
+
+#### `(^?)`
+
+``` purescript
+(^?) :: forall s t a b. s -> Fold (First a) s t a b -> Maybe a
+```
+
+_left-associative / precedence 8_
+
+Synonym for `preview`, flipped.
+
+#### `foldOf`
+
+``` purescript
+foldOf :: forall s t a b. Fold a s t a b -> s -> a
+```
+
+Folds all foci of a `Fold` to one. Note that this is the same as `view`.
+
+#### `foldMapOf`
+
+``` purescript
+foldMapOf :: forall s t a b r. Fold r s t a b -> (a -> r) -> s -> r
+```
+
+Maps and then folds all foci of a `Fold`.
+
+#### `foldrOf`
+
+``` purescript
+foldrOf :: forall s t a b r. Fold (Endo r) s t a b -> (a -> r -> r) -> r -> s -> r
+```
+
+Right fold over a `Fold`.
+
+#### `foldlOf`
+
+``` purescript
+foldlOf :: forall s t a b r. Fold (Dual (Endo r)) s t a b -> (r -> a -> r) -> r -> s -> r
+```
+
+Left fold over a `Fold`.
+
+#### `allOf`
+
+``` purescript
+allOf :: forall s t a b r. (BooleanAlgebra r) => Fold (Conj r) s t a b -> (a -> r) -> s -> r
+```
+
+Whether all foci of a `Fold` satisfy a predicate.
+
+#### `anyOf`
+
+``` purescript
+anyOf :: forall s t a b r. (BooleanAlgebra r) => Fold (Disj r) s t a b -> (a -> r) -> s -> r
+```
+
+Whether any focus of a `Fold` satisfies a predicate.
+
+#### `andOf`
+
+``` purescript
+andOf :: forall s t a b. (BooleanAlgebra a) => Fold (Conj a) s t a b -> s -> a
+```
+
+The conjunction of all foci of a `Fold`.
+
+#### `orOf`
+
+``` purescript
+orOf :: forall s t a b. (BooleanAlgebra a) => Fold (Disj a) s t a b -> s -> a
+```
+
+The disjunction of all foci of a `Fold`.
+
+#### `elemOf`
+
+``` purescript
+elemOf :: forall s t a b. (Eq a) => Fold (Disj Boolean) s t a b -> a -> s -> Boolean
+```
+
+Whether a `Fold` contains a given element.
+
+#### `notElemOf`
+
+``` purescript
+notElemOf :: forall s t a b. (Eq a) => Fold (Conj Boolean) s t a b -> a -> s -> Boolean
+```
+
+Whether a `Fold` not contains a given element.
+
+#### `sumOf`
+
+``` purescript
+sumOf :: forall s t a b. (Semiring a) => Fold (Additive a) s t a b -> s -> a
+```
+
+The sum of all foci of a `Fold`.
+
+#### `productOf`
+
+``` purescript
+productOf :: forall s t a b. (Semiring a) => Fold (Multiplicative a) s t a b -> s -> a
+```
+
+The product of all foci of a `Fold`.
+
+#### `lengthOf`
+
+``` purescript
+lengthOf :: forall s t a b. Fold (Additive Int) s t a b -> s -> Int
+```
+
+The number of foci of a `Fold`.
+
+#### `firstOf`
+
+``` purescript
+firstOf :: forall s t a b. Fold (First a) s t a b -> s -> Maybe a
+```
+
+The first focus of a `Fold`, if there is any. Synonym for `preview`.
+
+#### `lastOf`
+
+``` purescript
+lastOf :: forall s t a b. Fold (Last a) s t a b -> s -> Maybe a
+```
+
+The last focus of a `Fold`, if there is any.
+
+#### `maximumOf`
+
+``` purescript
+maximumOf :: forall s t a b. (Ord a) => Fold (Endo (Maybe a)) s t a b -> s -> Maybe a
+```
+
+The maximum of all foci of a `Fold`, if there is any.
+
+#### `minimumOf`
+
+``` purescript
+minimumOf :: forall s t a b. (Ord a) => Fold (Endo (Maybe a)) s t a b -> s -> Maybe a
+```
+
+The minimum of all foci of a `Fold`, if there is any.
+
+#### `findOf`
+
+``` purescript
+findOf :: forall s t a b. Fold (Endo (Maybe a)) s t a b -> (a -> Boolean) -> s -> Maybe a
+```
+
+Find the first focus of a `Fold` that satisfies a predicate, if there is any.
+
+#### `sequenceOf_`
+
+``` purescript
+sequenceOf_ :: forall f s t a b. (Applicative f) => Fold (Endo (f Unit)) s t (f a) b -> s -> f Unit
+```
+
+Sequence the foci of a `Fold`, pulling out an `Applicative`, and ignore
+the result. If you need the result, see `sequenceOf` for `Traversal`s.
+
+#### `toListOf`
+
+``` purescript
+toListOf :: forall s t a b. Fold (Endo (List a)) s t a b -> s -> List a
+```
+
+Collects the foci of a `Fold` into a list.
+
+#### `(^..)`
+
+``` purescript
+(^..) :: forall s t a b. s -> Fold (Endo (List a)) s t a b -> List a
+```
+
+_left-associative / precedence 8_
+
+Synonym for `toListOf`, reversed.
+
+#### `has`
+
+``` purescript
+has :: forall s t a b r. (BooleanAlgebra r) => Fold (Disj r) s t a b -> s -> r
+```
+
+Determines whether a `Fold` has at least one focus.
+
+#### `hasn't`
+
+``` purescript
+hasn't :: forall s t a b r. (BooleanAlgebra r) => Fold (Conj r) s t a b -> s -> r
+```
+
+Determines whether a `Fold` does not have a focus.
+
+#### `filtered`
+
+``` purescript
+filtered :: forall p a. (Choice p) => (a -> Boolean) -> OpticP p a a
+```
+
+Filters on a predicate.
+
+#### `replicated`
+
+``` purescript
+replicated :: forall a b t f. (Applicative f, Contravariant f) => Int -> Optic (Star f) a b a t
+```
+
+Replicates the elements of a fold.
+
+

--- a/docs/Photons/Getter.md
+++ b/docs/Photons/Getter.md
@@ -1,0 +1,31 @@
+## Module Photons.Getter
+
+This module defines functions for working with getters.
+
+#### `view`
+
+``` purescript
+view :: forall s t a b. Getter s t a b -> s -> a
+```
+
+View the focus of a `Getter`.
+
+#### `(^.)`
+
+``` purescript
+(^.) :: forall s t a b. s -> Getter s t a b -> a
+```
+
+_left-associative / precedence 8_
+
+Synonym for `view`, flipped.
+
+#### `to`
+
+``` purescript
+to :: forall s a f. (Contravariant f) => (s -> a) -> GetterP s a
+```
+
+Convert a function into a getter.
+
+

--- a/docs/Photons/Index.md
+++ b/docs/Photons/Index.md
@@ -1,0 +1,21 @@
+## Module Photons.Index
+
+#### `Index`
+
+``` purescript
+class (IndexKey m a, IndexValue m b) <= Index m a b where
+  ix :: a -> TraversalP m b
+```
+
+##### Instances
+``` purescript
+instance indexArr :: (Eq i) => Index (i -> a) i a
+instance indexMaybe :: Index (Maybe a) Unit a
+instance indexIdentity :: Index (Identity a) Unit a
+instance indexArray :: Index (Array a) Int a
+instance indexSet :: (Ord a) => Index (Set a) a Unit
+instance indexMap :: (Ord k) => Index (Map k v) k v
+instance indexStrMap :: Index (StrMap v) String v
+```
+
+

--- a/docs/Photons/Index/Class.md
+++ b/docs/Photons/Index/Class.md
@@ -1,0 +1,37 @@
+## Module Photons.Index.Class
+
+#### `IndexKey`
+
+``` purescript
+class IndexKey m k
+```
+
+##### Instances
+``` purescript
+instance indexKeyFn :: IndexKey (a -> b) a
+instance indexKeyArray :: IndexKey (Array a) Int
+instance indexKeyIdentity :: IndexKey (Identity a) Unit
+instance indexKeyMap :: IndexKey (Map k v) k
+instance indexKeyMaybe :: IndexKey (Maybe a) Unit
+instance indexKeySet :: IndexKey (Set k) k
+instance indexKeyStrMap :: IndexKey (StrMap v) String
+```
+
+#### `IndexValue`
+
+``` purescript
+class IndexValue m v
+```
+
+##### Instances
+``` purescript
+instance indexValueFn :: IndexValue (a -> b) b
+instance indexValueArray :: IndexValue (Array a) a
+instance indexValueIdentity :: IndexValue (Identity a) a
+instance indexValueMap :: IndexValue (Map k v) v
+instance indexValueMaybe :: IndexValue (Maybe a) a
+instance indexValueSet :: IndexValue (Set k) Unit
+instance indexValueStrMap :: IndexValue (StrMap v) v
+```
+
+

--- a/docs/Photons/Internal/Exchange.md
+++ b/docs/Photons/Internal/Exchange.md
@@ -1,0 +1,20 @@
+## Module Photons.Internal.Exchange
+
+This module defines the `Exchange` profunctor
+
+#### `Exchange`
+
+``` purescript
+data Exchange a b s t
+  = Exchange (s -> a) (b -> t)
+```
+
+The `Exchange` profunctor characterizes an `Iso`.
+
+##### Instances
+``` purescript
+instance functorExchange :: Functor (Exchange a b s)
+instance profunctorExchange :: Profunctor (Exchange a b)
+```
+
+

--- a/docs/Photons/Internal/Market.md
+++ b/docs/Photons/Internal/Market.md
@@ -1,0 +1,21 @@
+## Module Photons.Internal.Market
+
+This module defines the `Market` profunctor
+
+#### `Market`
+
+``` purescript
+data Market a b s t
+  = Market (b -> t) (s -> Either t a)
+```
+
+The `Market` profunctor characterizes a `Prism`.
+
+##### Instances
+``` purescript
+instance functorMarket :: Functor (Market a b s)
+instance profunctorMarket :: Profunctor (Market a b)
+instance choiceMarket :: Choice (Market a b)
+```
+
+

--- a/docs/Photons/Internal/Shop.md
+++ b/docs/Photons/Internal/Shop.md
@@ -1,0 +1,20 @@
+## Module Photons.Internal.Shop
+
+This module defines the `Shop` profunctor
+
+#### `Shop`
+
+``` purescript
+data Shop a b s t
+  = Shop (s -> a) (s -> b -> t)
+```
+
+The `Shop` profunctor characterizes a `Lens`.
+
+##### Instances
+``` purescript
+instance profunctorShop :: Profunctor (Shop a b)
+instance strongShop :: Strong (Shop a b)
+```
+
+

--- a/docs/Photons/Internal/Tagged.md
+++ b/docs/Photons/Internal/Tagged.md
@@ -1,0 +1,24 @@
+## Module Photons.Internal.Tagged
+
+This module defines the `Tagged` profunctor
+
+#### `Tagged`
+
+``` purescript
+newtype Tagged a b
+  = Tagged b
+```
+
+##### Instances
+``` purescript
+instance taggedProfunctor :: Profunctor Tagged
+instance taggedChoice :: Choice Tagged
+```
+
+#### `unTagged`
+
+``` purescript
+unTagged :: forall a b. Tagged a b -> b
+```
+
+

--- a/docs/Photons/Internal/Wander.md
+++ b/docs/Photons/Internal/Wander.md
@@ -1,0 +1,20 @@
+## Module Photons.Internal.Wander
+
+This module defines the `Wander` type class, which is used to define `Traversal`s.
+
+#### `Wander`
+
+``` purescript
+class (Strong p, Choice p) <= Wander p where
+  wander :: forall s t a b. (forall f. (Applicative f) => (a -> f b) -> s -> f t) -> p a b -> p s t
+```
+
+Class for profunctors that support polymorphic traversals.
+
+##### Instances
+``` purescript
+instance wanderFunction :: Wander Function
+instance wanderStar :: (Applicative f) => Wander (Star f)
+```
+
+

--- a/docs/Photons/Iso.md
+++ b/docs/Photons/Iso.md
@@ -1,0 +1,65 @@
+## Module Photons.Iso
+
+This module defines functions for working with isomorphisms.
+
+#### `iso`
+
+``` purescript
+iso :: forall s t a b. (s -> a) -> (b -> t) -> Iso s t a b
+```
+
+Create an `Iso` from a pair of morphisms.
+
+#### `withIso`
+
+``` purescript
+withIso :: forall s t a b r. AnIso s t a b -> ((s -> a) -> (b -> t) -> r) -> r
+```
+
+Extracts the pair of morphisms from an isomorphism.
+
+#### `cloneIso`
+
+``` purescript
+cloneIso :: forall s t a b. AnIso s t a b -> Iso s t a b
+```
+
+Extracts an `Iso` from `AnIso`.
+
+#### `au`
+
+``` purescript
+au :: forall s t a b e. AnIso s t a b -> ((b -> t) -> e -> s) -> e -> a
+```
+
+#### `auf`
+
+``` purescript
+auf :: forall s t a b e r p. (Profunctor p) => AnIso s t a b -> (p r a -> e -> b) -> p r s -> e -> t
+```
+
+#### `under`
+
+``` purescript
+under :: forall s t a b. AnIso s t a b -> (t -> s) -> b -> a
+```
+
+#### `curried`
+
+``` purescript
+curried :: forall a b c d e f. Iso (Tuple a b -> c) (Tuple d e -> f) (a -> b -> c) (d -> e -> f)
+```
+
+#### `uncurried`
+
+``` purescript
+uncurried :: forall a b c d e f. Iso (a -> b -> c) (d -> e -> f) (Tuple a b -> c) (Tuple d e -> f)
+```
+
+#### `flipped`
+
+``` purescript
+flipped :: forall a b c d e f. Iso (a -> b -> c) (d -> e -> f) (b -> a -> c) (e -> d -> f)
+```
+
+

--- a/docs/Photons/Lens.md
+++ b/docs/Photons/Lens.md
@@ -1,0 +1,31 @@
+## Module Photons.Lens
+
+This module defines functions for working with lenses.
+
+#### `lens'`
+
+``` purescript
+lens' :: forall s t a b. (s -> Tuple a (b -> t)) -> Lens s t a b
+```
+
+#### `lens`
+
+``` purescript
+lens :: forall s t a b. (s -> a) -> (s -> b -> t) -> Lens s t a b
+```
+
+Create a `Lens` from a getter/setter pair.
+
+#### `withLens`
+
+``` purescript
+withLens :: forall s t a b r. ALens s t a b -> ((s -> a) -> (s -> b -> t) -> r) -> r
+```
+
+#### `cloneLens`
+
+``` purescript
+cloneLens :: forall s t a b. ALens s t a b -> Lens s t a b
+```
+
+

--- a/docs/Photons/Lens/Tuple.md
+++ b/docs/Photons/Lens/Tuple.md
@@ -1,0 +1,19 @@
+## Module Photons.Lens.Tuple
+
+#### `_1`
+
+``` purescript
+_1 :: forall a b c. Lens (Tuple a c) (Tuple b c) a b
+```
+
+Lens for the first component of a `Tuple`.
+
+#### `_2`
+
+``` purescript
+_2 :: forall a b c. Lens (Tuple c a) (Tuple c b) a b
+```
+
+Lens for the second component of a `Tuple`.
+
+

--- a/docs/Photons/Lens/Unit.md
+++ b/docs/Photons/Lens/Unit.md
@@ -1,0 +1,11 @@
+## Module Photons.Lens.Unit
+
+#### `united`
+
+``` purescript
+united :: forall a. LensP a Unit
+```
+
+There is a `Unit` in everything.
+
+

--- a/docs/Photons/Lens/Void.md
+++ b/docs/Photons/Lens/Void.md
@@ -1,0 +1,11 @@
+## Module Photons.Lens.Void
+
+#### `devoid`
+
+``` purescript
+devoid :: forall a. LensP Void a
+```
+
+There is everything in `Void`.
+
+

--- a/docs/Photons/Prism.md
+++ b/docs/Photons/Prism.md
@@ -1,0 +1,69 @@
+## Module Photons.Prism
+
+This module defines functions for working with prisms.
+
+#### `prism`
+
+``` purescript
+prism :: forall s t a b. (b -> t) -> (s -> Either t a) -> Prism s t a b
+```
+
+Create a `Prism` from a constructor/pattern pair.
+
+#### `prism'`
+
+``` purescript
+prism' :: forall s a. (a -> s) -> (s -> Maybe a) -> PrismP s a
+```
+
+#### `review`
+
+``` purescript
+review :: forall s t a b. Review s t a b -> b -> t
+```
+
+Review a value through a `Prism`.
+
+#### `nearly`
+
+``` purescript
+nearly :: forall a. a -> (a -> Boolean) -> PrismP a Unit
+```
+
+#### `only`
+
+``` purescript
+only :: forall a. (Eq a) => a -> Prism a a Unit Unit
+```
+
+#### `clonePrism`
+
+``` purescript
+clonePrism :: forall s t a b. APrism s t a b -> Prism s t a b
+```
+
+#### `withPrism`
+
+``` purescript
+withPrism :: forall s t a b r. APrism s t a b -> ((b -> t) -> (s -> Either t a) -> r) -> r
+```
+
+#### `matching`
+
+``` purescript
+matching :: forall s t a b. APrism s t a b -> s -> Either t a
+```
+
+#### `is`
+
+``` purescript
+is :: forall s t a b r. (BooleanAlgebra r) => APrism s t a b -> s -> r
+```
+
+#### `isn't`
+
+``` purescript
+isn't :: forall s t a b r. (BooleanAlgebra r) => APrism s t a b -> s -> r
+```
+
+

--- a/docs/Photons/Prism/Either.md
+++ b/docs/Photons/Prism/Either.md
@@ -1,0 +1,19 @@
+## Module Photons.Prism.Either
+
+#### `_Left`
+
+``` purescript
+_Left :: forall a b c. Prism (Either a c) (Either b c) a b
+```
+
+Prism for the `Left` constructor of `Either`.
+
+#### `_Right`
+
+``` purescript
+_Right :: forall a b c. Prism (Either c a) (Either c b) a b
+```
+
+Prism for the `Right` constructor of `Either`.
+
+

--- a/docs/Photons/Prism/Maybe.md
+++ b/docs/Photons/Prism/Maybe.md
@@ -1,0 +1,19 @@
+## Module Photons.Prism.Maybe
+
+#### `_Nothing`
+
+``` purescript
+_Nothing :: forall a b. Prism (Maybe a) (Maybe b) Unit Unit
+```
+
+Prism for the `Nothing` constructor of `Maybe`.
+
+#### `_Just`
+
+``` purescript
+_Just :: forall a b. Prism (Maybe a) (Maybe b) a b
+```
+
+Prism for the `Just` constructor of `Maybe`.
+
+

--- a/docs/Photons/Setter.md
+++ b/docs/Photons/Setter.md
@@ -1,0 +1,113 @@
+## Module Photons.Setter
+
+This module defines functions for working with setters.
+
+#### `over`
+
+``` purescript
+over :: forall s t a b. Setter s t a b -> (a -> b) -> s -> t
+```
+
+Apply a function to the foci of a `Setter`.
+
+#### `(%~)`
+
+``` purescript
+(%~) :: forall s t a b. Setter s t a b -> (a -> b) -> s -> t
+```
+
+_right-associative / precedence 4_
+
+Synonym for `over`.
+
+#### `set`
+
+``` purescript
+set :: forall s t a b. Setter s t a b -> b -> s -> t
+```
+
+Set the foci of a `Setter` to a constant value.
+
+#### `(.~)`
+
+``` purescript
+(.~) :: forall s t a b. Setter s t a b -> b -> s -> t
+```
+
+_right-associative / precedence 4_
+
+Synonym for `set`.
+
+#### `(+~)`
+
+``` purescript
+(+~) :: forall s t a. (Semiring a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(*~)`
+
+``` purescript
+(*~) :: forall s t a. (Semiring a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(-~)`
+
+``` purescript
+(-~) :: forall s t a. (Ring a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(//~)`
+
+``` purescript
+(//~) :: forall s t a. (DivisionRing a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(||~)`
+
+``` purescript
+(||~) :: forall s t a. (BooleanAlgebra a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(&&~)`
+
+``` purescript
+(&&~) :: forall s t a. (BooleanAlgebra a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(<>~)`
+
+``` purescript
+(<>~) :: forall s t a. (Semigroup a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(++~)`
+
+``` purescript
+(++~) :: forall s t a. (Semigroup a) => Setter s t a a -> a -> s -> t
+```
+
+_right-associative / precedence 4_
+
+#### `(?~)`
+
+``` purescript
+(?~) :: forall s t a b. Setter s t a (Maybe b) -> b -> s -> t
+```
+
+_right-associative / precedence 4_
+
+

--- a/docs/Photons/Traversal.md
+++ b/docs/Photons/Traversal.md
@@ -1,0 +1,39 @@
+## Module Photons.Traversal
+
+This module defines functions for working with traversals.
+
+#### `traversed`
+
+``` purescript
+traversed :: forall t a b. (Traversable t) => Traversal (t a) (t b) a b
+```
+
+Create a `Traversal` which traverses the elements of a `Traversable` functor.
+
+#### `traverseOf`
+
+``` purescript
+traverseOf :: forall f s t a b. (Applicative f) => Optic (Star f) s t a b -> (a -> f b) -> s -> f t
+```
+
+Turn a pure profunctor `Traversal` into a `lens`-like `Traversal`.
+
+#### `sequenceOf`
+
+``` purescript
+sequenceOf :: forall f s t a. (Applicative f) => Optic (Star f) s t (f a) a -> s -> f t
+```
+
+Sequence the foci of a `Traversal`, pulling out an `Applicative` effect.
+If you do not need the result, see `sequenceOf_` for `Fold`s.
+
+#### `failover`
+
+``` purescript
+failover :: forall f s t a b. (Alternative f) => Optic (Star (Tuple (Disj Boolean))) s t a b -> (a -> b) -> s -> f t
+```
+
+Tries to map over a `Traversal`; returns `empty` if the traversal did
+not have any new focus.
+
+

--- a/docs/Photons/Types.md
+++ b/docs/Photons/Types.md
@@ -1,0 +1,167 @@
+## Module Photons.Types
+
+This module defines types for working with lenses.
+
+#### `Optic`
+
+``` purescript
+type Optic p s t a b = p a b -> p s t
+```
+
+A general-purpose Photons.
+
+#### `OpticP`
+
+``` purescript
+type OpticP p s a = Optic p s s a a
+```
+
+#### `Iso`
+
+``` purescript
+type Iso s t a b = forall p. (Profunctor p) => Optic p s t a b
+```
+
+A generalized isomorphism.
+
+#### `IsoP`
+
+``` purescript
+type IsoP s a = Iso s s a a
+```
+
+#### `AnIso`
+
+``` purescript
+type AnIso s t a b = Optic (Exchange a b) s t a b
+```
+
+#### `AnIsoP`
+
+``` purescript
+type AnIsoP s a = AnIso s s a a
+```
+
+#### `Lens`
+
+``` purescript
+type Lens s t a b = forall p. (Strong p) => Optic p s t a b
+```
+
+A lens.
+
+#### `LensP`
+
+``` purescript
+type LensP s a = Lens s s a a
+```
+
+#### `ALens`
+
+``` purescript
+type ALens s t a b = Optic (Shop a b) s t a b
+```
+
+#### `ALensP`
+
+``` purescript
+type ALensP s a = ALens s s a a
+```
+
+#### `Prism`
+
+``` purescript
+type Prism s t a b = forall p. (Choice p) => Optic p s t a b
+```
+
+A prism.
+
+#### `PrismP`
+
+``` purescript
+type PrismP s a = Prism s s a a
+```
+
+#### `APrism`
+
+``` purescript
+type APrism s t a b = Optic (Market a b) s t a b
+```
+
+#### `APrismP`
+
+``` purescript
+type APrismP s a = APrism s s a a
+```
+
+#### `Traversal`
+
+``` purescript
+type Traversal s t a b = forall p. (Wander p) => Optic p s t a b
+```
+
+A traversal.
+
+#### `TraversalP`
+
+``` purescript
+type TraversalP s a = Traversal s s a a
+```
+
+#### `Getter`
+
+``` purescript
+type Getter s t a b = Fold a s t a b
+```
+
+A getter.
+
+#### `GetterP`
+
+``` purescript
+type GetterP s a = Getter s s a a
+```
+
+#### `Setter`
+
+``` purescript
+type Setter s t a b = Optic Function s t a b
+```
+
+A setter.
+
+#### `SetterP`
+
+``` purescript
+type SetterP s a = Setter s s a a
+```
+
+#### `Review`
+
+``` purescript
+type Review s t a b = Optic Tagged s t a b
+```
+
+A review.
+
+#### `ReviewP`
+
+``` purescript
+type ReviewP s a = Review s s a a
+```
+
+#### `Fold`
+
+``` purescript
+type Fold r s t a b = Optic (Star (Const r)) s t a b
+```
+
+A fold.
+
+#### `FoldP`
+
+``` purescript
+type FoldP r s a = Fold r s s a a
+```
+
+

--- a/src/Photons/At.purs
+++ b/src/Photons/At.purs
@@ -2,40 +2,41 @@ module Photons.At where
 
 import Prelude
 
--- import Data.Identity (runIdentity, Identity(..))
--- import Data.Map as M
+import Data.Identity (runIdentity, Identity(..))
+import Data.Map as M
 import Data.Maybe (Maybe(..), maybe)
--- import Data.Set as S
--- import Data.StrMap as SM
+import Data.Set as S
+import Data.StrMap as SM
+import Data.Tuple
 
 import Photons.Index (Index)
-import Photons.Types (LensFP())
+import Photons.Lens (LensP(), lens)
 
 class (Index m a b) <= At m a b where
-  at :: a -> LensFP m (Maybe b)
+  at :: a -> LensP m (Maybe b)
 
--- instance atIdentity :: At (Identity a) Unit a where
---   at _ ma2fMa i@(Identity a) = maybe i Identity <$> ma2fMa (Just a)
+instance atIdentity :: At (Identity a) Unit a where
+  at _ = lens (Just <<< runIdentity) (flip maybe Identity)
 
--- instance atMaybe :: At (Maybe a) Unit a where
---   at _ = ($)
+instance atMaybe :: At (Maybe a) Unit a where
+  at _ = lens id \_ -> id
 
--- instance atSet :: (Ord v) => At (S.Set v) v Unit where
---   at v mu2fMu s = go <$> mu2fMu s'
---     where s' = if S.member v s then Just unit else Nothing
---           go Nothing  = maybe s (\_ -> S.delete v s) s'
---           go (Just _) = S.insert v s
+instance atSet :: (Ord v) => At (S.Set v) v Unit where
+  at x = lens get (flip update)
+    where
+      get xs =
+        if S.member x xs
+           then Just unit
+           else Nothing
+      update Nothing = S.delete x
+      update (Just _) = S.insert x
 
--- instance atMap :: (Ord k) => At (M.Map k v) k v where
---   at k mv2fMv m = go <$> mv2fMv m'
---     where
---       m' = M.lookup k m
---       go Nothing  = maybe m (\_ -> M.delete k m) m'
---       go (Just v) = M.insert k v m
+instance atMap :: (Ord k) => At (M.Map k v) k v where
+  at k =
+    lens (M.lookup k) \m ->
+      maybe (M.delete k m) \v -> M.insert k v m
 
--- instance atStrMap :: At (SM.StrMap v) String v where
---   at k mv2fMv sm = go <$> mv2fMv sm'
---     where
---       sm' = SM.lookup k sm
---       go Nothing  = maybe sm (\_ -> SM.delete k sm) sm'
---       go (Just v) = SM.insert k v sm
+instance atStrMap :: At (SM.StrMap v) String v where
+  at k =
+    lens (SM.lookup k) \m ->
+      maybe (SM.delete k m) \ v -> SM.insert k v m

--- a/src/Photons/Contains.purs
+++ b/src/Photons/Contains.purs
@@ -1,15 +1,18 @@
-module Photons.Contains where
+module Photons.Contains
+  ( Contains
+  , contains
+  ) where
 
 import Prelude
 
--- import Data.Set (Set(), delete, insert, member)
+import Data.Set as S
+import Data.Tuple
 
 import Photons.Index.Class (IndexKey)
-import Photons.Types (LensFP())
+import Photons.Lens (LensP(), lens)
 
 class (IndexKey m a) <= Contains m a where
-  contains :: a -> LensFP m Boolean
+  contains :: a -> LensP m Boolean
 
--- instance containsSet :: (Ord k) => Contains (Set k) k where
---   contains k f s =
---     (\b -> if b then insert k s else delete k s) <$> f (member k s)
+instance containsSet :: (Ord k) => Contains (S.Set k) k where
+  contains x = lens (S.member x) \xs b -> if b then S.insert x xs else S.delete x xs

--- a/src/Photons/Index.purs
+++ b/src/Photons/Index.purs
@@ -2,41 +2,58 @@ module Photons.Index where
 
 import Prelude
 
--- import Data.Identity (Identity(..))
--- import Data.Map as M
--- import Data.Maybe (maybe, Maybe(..))
--- import Data.Set as S
--- import Data.StrMap as SM
+import Data.Identity (Identity(..))
+import Data.Map as M
+import Data.Maybe (maybe, fromMaybe, Maybe(..))
+import Data.Set as S
+import Data.StrMap as SM
+import Data.Array as A
 
+import Data.Traversable (traverse)
 import Photons.Index.Class (IndexKey, IndexValue)
+import Photons.Internal.Wander
 import Photons.Types (TraversalP())
 
 class (IndexKey m a, IndexValue m b) <= Index m a b where
   ix :: a -> TraversalP m b
 
--- instance indexArr :: (Eq e) => Index (e -> a) e a where
---   ix e a2fa e2a = (\a e' -> if e == e' then a else e2a e') <$> a2fa (e2a e)
+instance indexArr :: (Eq i) => Index (i -> a) i a where
+  ix i =
+    wander \coalg f ->
+      coalg (f i) <#> \a j ->
+        if i == j then a else f j
 
--- instance indexMaybe :: Index (Maybe a) Unit a where
---   ix _ _    Nothing  = pure Nothing
---   ix _ a2fa (Just a) = Just <$> a2fa a
+instance indexMaybe :: Index (Maybe a) Unit a where
+  ix _ = wander traverse
 
--- instance indexIdentity :: Index (Identity a) Unit a where
---   ix _ a2fa (Identity a) = Identity <$> a2fa a
+instance indexIdentity :: Index (Identity a) Unit a where
+  ix _ = wander traverse
 
--- instance indexArray :: Index (Array a) Number a where
---   ix n _    as | n < 0 = pure as
---   ix _ _    []         = pure []
-  -- ix 0 a2fa (a:as)     = a2fa a <#> \a' -> a':as
-  -- ix n a2fa (a:as)     = (:) a <$> ix (n - 1) a2fa as
+instance indexArray :: Index (Array a) Int a where
+  ix n =
+    wander \coalg xs ->
+      xs A.!! n #
+        maybe
+          (pure xs)
+          (coalg >>> map \x -> fromMaybe xs (A.updateAt n x xs))
 
--- instance indexSet :: (Ord a) => Index (S.Set a) a Unit where
---   ix a u2fu s = if S.member a s then pure $ S.insert a s else pure s
+instance indexSet :: (Ord a) => Index (S.Set a) a Unit where
+  ix x =
+    wander \coalg ->
+      pure <<< S.insert x
 
--- instance indexMap :: (Ord k) => Index (M.Map k v) k v where
---   ix k v2fv m = M.lookup k m # maybe (pure m) \v ->
---     (\v' -> M.insert k v' m) <$> v2fv v
+instance indexMap :: (Ord k) => Index (M.Map k v) k v where
+  ix k =
+    wander \coalg m ->
+      M.lookup k m #
+        maybe
+          (pure m)
+          (coalg >>> map \v -> M.insert k v m)
 
--- instance indexStrMap :: Index (SM.StrMap v) String v where
---   ix str v2fv sm = SM.lookup str sm # maybe (pure sm) \v ->
---     (\v' -> SM.insert str v' sm) <$> v2fv v
+instance indexStrMap :: Index (SM.StrMap v) String v where
+  ix k =
+    wander \coalg m ->
+      SM.lookup k m #
+        maybe
+          (pure m)
+          (coalg >>> map \v -> SM.insert k v m)

--- a/src/Photons/Types.purs
+++ b/src/Photons/Types.purs
@@ -37,9 +37,6 @@ type AnIsoP s a = AnIso s s a a
 type Lens s t a b = forall p. (Strong p) => Optic p s t a b
 type LensP s a = Lens s s a a
 
-type LensF s t a b = Optic (->) s t a b
-type LensFP s a = LensF s s a a
-
 type ALens s t a b = Optic (Shop a b) s t a b
 type ALensP s a = ALens s s a a
 


### PR DESCRIPTION
Also removed the `LensF` types, which don't seem to be what was intended.

It looks like it actually isn't possible to treat indexed traversals nicely with profunctor lenses (at least, not possible in the naïve sense that we thought momentarily), but I don't think we're actually using these very heavily, or at all. What's more, in most cases where you would want an indexed traversal, there's a "reasonable" (but slightly less fancy) way to do it with a plain old traversal; for instance, rather than an indexed traversal over a map, you could view the map in extension (i.e. key-value pairs) and traverse over that.